### PR TITLE
Improve diagnosis for non-existing components

### DIFF
--- a/bin/builder.js
+++ b/bin/builder.js
@@ -43,6 +43,9 @@ const identifiers = require(path.join(rtPath, 'identifiers.js'))
 
 function processComponent(variables, component) {
   const identifier = identifiers[component]
+  if (!identifier) {
+    throw('Unknown component ' + component + '. Must be one of: ' + Object.keys(identifiers).join(', '))
+  }
   const componentPath = path.join(rtPath, getPath(component))
   return postcssWithModules(identifier, componentPath, variables, rtPath, config.fixed)
 }


### PR DESCRIPTION
When a non-themable component is listed in the include list, such as `FONT_ICON`, or on a typo, the `path.join` that produces `componentPath` produces an error that gives no clue as to the actual problem.  This fix detects the error, reports which is the wrong/misspelled component and lists the available ones.